### PR TITLE
Use simplecov with codeclimate as just another formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in dug.gemspec
 gemspec
-
-group :test do
-  gem "codeclimate-test-reporter", require: nil
-end

--- a/dug.gemspec
+++ b/dug.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["chris@chrisarcand.com"]
 
   spec.summary       = %q{[D]amn yo[u], [G]mail. A gem to organize your GitHub notification emails in ways Gmail filters can't.}
-  spec.description   = %q{[D]amn yo[u], [G]mail. A gemified script to organize your GitHub notification emails using a simple configuration file in ways Gmail filters can't, such as X-GitHub-Reason headers.}
+  spec.description   = %q{A simple, configurable gem to organize your GitHub notification emails in ways Gmail can't and in an easier-to-maintain way than large, slow Google Apps Scripts.}
   spec.homepage      = "https://github.com/chrisarcand/dug"
   spec.license       = "MIT"
 
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "codeclimate-test-reporter", "~> 0"
+  spec.add_development_dependency "simplecov", "~> 0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+require 'codeclimate-test-reporter'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  CodeClimate::TestReporter::Formatter
+])
+SimpleCov.start
 
 require 'dug'
 require 'minitest/autorun'


### PR DESCRIPTION
Simplecov is good; I had it added before but tossed it when I wanted to add codeclimate's gem. TIL you can just use codeclimate as another simplecov formatter, so this adds it back to get the nice HTML output from simplecov once again.
