### PR TITLE
MessageProcessor Extraction

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,12 +3,5 @@
 require "bundler/setup"
 require "dug"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start
+require "pry"
+Pry.start

--- a/dug.gemspec
+++ b/dug.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "pry", "~> 0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-reporters", "~> 1.0"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0"

--- a/dug.gemspec
+++ b/dug.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest-reporters", "~> 1.0"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0"
   spec.add_development_dependency "simplecov", "~> 0"
 end

--- a/lib/dug.rb
+++ b/lib/dug.rb
@@ -2,6 +2,7 @@ require "dug/version"
 require "dug/configurator"
 require "dug/gmail_servicer"
 require "dug/logger"
+require "dug/message_processor"
 require "dug/notification_decorator"
 require "dug/runner"
 

--- a/lib/dug/logger.rb
+++ b/lib/dug/logger.rb
@@ -1,7 +1,11 @@
 module Dug
   module Logger
+    # TODO This obviously needs a lot of love
+
     def log(message, level: :info)
-      puts "[#{level.to_s.upcase}] #{Time.now} - #{message}"
+      unless $testing
+        puts "[#{level.to_s.upcase}] #{Time.now} - #{message}"
+      end
     end
   end
 end

--- a/lib/dug/message_processor.rb
+++ b/lib/dug/message_processor.rb
@@ -1,0 +1,51 @@
+module Dug
+  class MessageProcessor
+    # Private API for processing individual Gmail messages
+
+    include Dug::Logger
+
+    def initialize(message_id, servicer)
+      @servicer = servicer
+      @message  = NotificationDecorator.new(servicer.get_user_message('me', message_id))
+    end
+
+    def execute
+      if message.reason && label = Dug.configuration.label_for(:reason, message.reason)
+        labels_to_add << label
+      end
+
+      if label = Dug.configuration.label_for(:organization, message.organization)
+        labels_to_add << label
+      end
+
+      if label = Dug.configuration.label_for(:repository, message.repository, organization: message.organization)
+        labels_to_add << label
+      end
+
+      info = "Processing message:"
+      info << "\n    ID: #{message.id}"
+      %w(Date From Subject).each do |header|
+        info << "\n    #{header}: #{message.headers[header]}"
+      end
+      info << "\n    * Applying labels: #{labels_to_add.join(' | ')} *"
+      log(info)
+
+      servicer.add_labels_by_name(message, labels_to_add)
+      servicer.remove_labels_by_name(message, labels_to_remove)
+    end
+
+    def labels_to_add
+      @labels_to_add ||= ["GitHub"]
+    end
+
+    def labels_to_remove
+      @labels_to_remove ||= ["GitHub/Unprocessed"]
+    end
+
+    private
+
+    attr_reader :message
+    attr_reader :servicer
+
+  end
+end

--- a/test/message_processor_test.rb
+++ b/test/message_processor_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class MessageProcessorTest < MiniTest::Test
+  class MentionedMessage
+    def id
+      "123abc"
+    end
+
+    def headers
+      { "Date" => "Some date", "From" => "Someone", "Subject" => "Some subject" }
+    end
+
+    def reason
+      "mention"
+    end
+
+    def organization
+      "chrisarcand"
+    end
+
+    def repository
+      "dug"
+    end
+  end
+
+  def setup
+    @mock_servicer = MiniTest::Mock.new
+  end
+
+  def test_correct_mentioned_labels
+    Dug.configure do |config|
+      config.set_organization_rule("chrisarcand")
+      config.set_repository_rule("dug", organization: "chrisarcand")
+      config.set_reason_rule("mention")
+    end
+
+    @mock_message  = MentionedMessage.new
+
+    Dug::NotificationDecorator.stub :new, @mock_message do
+      @mock_servicer.expect(:get_user_message, nil, [String, String])
+      @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "mention", "chrisarcand", "dug"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+
+      Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
+      @mock_servicer.verify
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,5 @@ end
 
 require 'dug'
 require 'minitest/autorun'
+require "minitest/reporters"
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+$testing = true
+
 # Because Code Climate stupidly doesn't defer to SimpleCov and
 # run if it's not actually posting to CC (not by design), so you
 # can't just add another formatter to SimpleCov as they claim.


### PR DESCRIPTION
Extracts message processing to its own class with tests, adds pry and minitest reporters, omits logging from tests
