### PR TITLE
Allow for different remotes with same-named projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,30 +36,31 @@ Basic installation steps:
   ```
   ---
   organizations:
-    - rails
-    - name: rspec
-      label: RSpec
-      repositories:
-        - name: rspec-expectations
-          label: RSpec/rspec-expectations
-    - ManageIQ
+    rails: Rails
+    rspec: RSpec
+    ManageIQ: ManageIQ
+
+  repositories:
+    rspec-expectations: RSpec/rspec-expectations
+    dug: dug
+    dotfiles:
+      - remote: chrisarcand
+        label: My dotfiles
+      - remote: juliancheal
+        label: Julian's dotfiles
 
   reasons:
-    author:
-      label: Participating
-    comment:
-      label: Participating
-    mention:
-      label: Mentioned by name
-    team_mention:
-      label: Team mention
-    assign:
-      label: Assigned to me
+    author: Participating
+    comment: Participating
+    mention: Mentioned
+    team_mention: Team mention
+    assign: Assigned to me
   ```
 
   The above rule file will:
   * Label all notifications from the organization `rails` with the label `rails`, `rspec` with `RSpec`, `ManageIQ` with `ManageIQ`.
-  * Label all notifications from the repository `rspec-expectations` with the label `RSpec/rspec-expectations`
+  * Label all notifications from the repository `rspec-expectations` with the label `RSpec/rspec-expectations`, `dug` with `dug`.
+  * Label all notifications from chrisarcand's `dotfiles` repository with the label `My dotfiles`, juliancheal's with `Julian's dotfiles`.
   * Label notifications with `Participating` if I am the author of the Issue/PR or if I commented on it.
   * Label notifications with `Mentioned by name` if I'm directly mentioned in it.
   * Label notifications with `Team mention` if a team I am a part of is mentioned in it.

--- a/lib/dug/configurator.rb
+++ b/lib/dug/configurator.rb
@@ -48,7 +48,7 @@ module Dug
       @rule_file
     end
 
-    def label_for(type, name)
+    def label_for(type, name, opts={})
       type = type.to_s
       validate_label_type!(type)
       validate_reason!(name) if type == 'reason'
@@ -57,8 +57,14 @@ module Dug
       case rule
       when String, nil
         rule
-      when Hash
-        rule['label']
+      when Array
+        if type == 'repository'
+          raise ArgumentError, "Multiple remotes possible and no remote specified" unless opts.keys.include?(:remote)
+          rule = rule.detect do |r|
+            r['remote'] == opts[:remote]
+          end
+          rule['label'] if rule
+        end
       end
     end
 

--- a/lib/dug/message_processor.rb
+++ b/lib/dug/message_processor.rb
@@ -11,8 +11,10 @@ module Dug
 
     def execute
       LABEL_RULE_TYPES.each do |type|
-        if message.public_send(type) && label = Dug.configuration.label_for(type, message.public_send(type))
-          labels_to_add << label
+        if message_data = message.public_send(type)
+          opts = type == 'repository' ? { remote: message.public_send(:organization) } : {}
+          label = Dug.configuration.label_for(type, message_data, opts)
+          labels_to_add << label if label
         end
       end
 

--- a/test/configurator/rule_file_fixtures/valid_rule_file.yml
+++ b/test/configurator/rule_file_fixtures/valid_rule_file.yml
@@ -8,6 +8,11 @@ organizations:
 repositories:
   rspec-expectations: RSpec/rspec-expectations
   dug: dug
+  dotfiles:
+    - remote: chrisarcand
+      label: My dotfiles
+    - remote: juliancheal
+      label: Julian's dotfiles
 
 reasons:
   author: Participating

--- a/test/message_processor_test.rb
+++ b/test/message_processor_test.rb
@@ -1,17 +1,14 @@
 require 'test_helper'
 
 class MessageProcessorTest < MiniTest::Test
-  class MentionedMessage
+
+  class BaseMessage
     def id
       "123abc"
     end
 
     def headers
       { "Date" => "Some date", "From" => "Someone", "Subject" => "Some subject" }
-    end
-
-    def reason
-      "mention"
     end
 
     def organization
@@ -21,22 +18,89 @@ class MessageProcessorTest < MiniTest::Test
     def repository
       "dug"
     end
+
+    def reason
+      nil
+    end
+  end
+
+  class MentionedMessage < BaseMessage
+    def reason
+      "mention"
+    end
+  end
+
+  class MultipleRemotesPossible < BaseMessage
+    def repository
+      "dotfiles"
+    end
+  end
+
+  class MultipleRemotesPossibleOtherMatch < MultipleRemotesPossible
+    def organization
+      "juliancheal"
+    end
+  end
+
+  class MultipleRemotesButNoMatch < MultipleRemotesPossible
+    def organization
+      "jphenow"
+    end
   end
 
   def setup
-    @mock_servicer = MiniTest::Mock.new
-  end
-
-  def test_correct_mentioned_labels
     Dug.configure do |config|
       config.rule_file = File.expand_path("../configurator/rule_file_fixtures/valid_rule_file.yml", __FILE__)
     end
 
+    @mock_servicer = MiniTest::Mock.new
+  end
+
+  def test_correct_mentioned_labels
     @mock_message  = MentionedMessage.new
 
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "dug", "Mentioned"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+
+      Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
+      @mock_servicer.verify
+    end
+  end
+
+  def test_multiple_remotes_possible_1
+    @mock_message = MultipleRemotesPossible.new
+
+    Dug::NotificationDecorator.stub :new, @mock_message do
+      @mock_servicer.expect(:get_user_message, nil, [String, String])
+      @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "My dotfiles"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+
+      Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
+      @mock_servicer.verify
+    end
+  end
+
+  def test_multiple_remotes_possible_2
+    @mock_message = MultipleRemotesPossibleOtherMatch.new
+
+    Dug::NotificationDecorator.stub :new, @mock_message do
+      @mock_servicer.expect(:get_user_message, nil, [String, String])
+      @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Julian's dotfiles"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+
+      Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
+      @mock_servicer.verify
+    end
+  end
+
+  def test_multiple_remotes_but_no_rule
+    @mock_message = MultipleRemotesButNoMatch.new
+
+    Dug::NotificationDecorator.stub :new, @mock_message do
+      @mock_servicer.expect(:get_user_message, nil, [String, String])
+      @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub"]])
       @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute


### PR DESCRIPTION
Lost this functionality with the config revamp, now returned in a much easier-to-use form. Good example is labeling people's dotfiles.

Closes #7 
