### PR TITLE
Feature: Merged, Closed, and Reopened

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,6 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run
 `rake test` to run the tests. You can also run `bin/console` for an interactive
 prompt that will allow you to experiment.
 
-## TODO
-* Add option to parse message body for labelling
-* Add more built-in reasons such as "Closed" statuses
-* The Google Auth Library has an API for Redis that could be supported easily.
-* Moar tests, plz
-
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/chrisarcand/dug.

--- a/lib/dug.rb
+++ b/lib/dug.rb
@@ -10,6 +10,7 @@ require "dug/runner"
 module Dug
   LABEL_RULE_TYPES = %w(organization repository reason state)
   GITHUB_REASONS = %w(author comment mention team_mention state_change assign manual subscribed)
+  ISSUE_STATES = %(merged closed reopened)
 
   def self.authorize!
     Dug::GmailServicer.new.authorize!

--- a/lib/dug.rb
+++ b/lib/dug.rb
@@ -8,7 +8,7 @@ require "dug/notification_decorator"
 require "dug/runner"
 
 module Dug
-  LABEL_RULE_TYPES = %w(organization repository reason)
+  LABEL_RULE_TYPES = %w(organization repository reason state)
   GITHUB_REASONS = %w(author comment mention team_mention state_change assign manual subscribed)
 
   def self.authorize!

--- a/lib/dug/message_processor.rb
+++ b/lib/dug/message_processor.rb
@@ -10,10 +10,17 @@ module Dug
     end
 
     def execute
-      LABEL_RULE_TYPES.each do |type|
+      %w(organization repository reason).each do |type|
         if message_data = message.public_send(type)
           opts = type == 'repository' ? { remote: message.public_send(:organization) } : {}
           label = Dug.configuration.label_for(type, message_data, opts)
+          labels_to_add << label if label
+        end
+      end
+
+      %w(merged closed).each do |state|
+        if message.public_send("indicates_#{state}?")
+          label = Dug.configuration.label_for(:state, state)
           labels_to_add << label if label
         end
       end

--- a/lib/dug/message_processor.rb
+++ b/lib/dug/message_processor.rb
@@ -38,10 +38,13 @@ module Dug
         info << "\n    #{header}: #{message.headers[header]}"
       end
       info << "\n    * Applying labels: #{labels_to_add.join(' | ')} *"
+      info << "\n    * Removing labels: #{labels_to_remove.join(' | ')} *"
       log(info)
 
       servicer.add_labels_by_name(message, labels_to_add)
-      servicer.remove_labels_by_name(message, labels_to_remove)
+      servicer.remove_labels_by_name(message,
+                                     labels_to_remove,
+                                     entire_thread: modify_entire_thread?)
     end
 
     def labels_to_add
@@ -50,6 +53,10 @@ module Dug
 
     def labels_to_remove
       @labels_to_remove ||= [Dug.configuration.unprocessed_label_name]
+      if @labels_to_remove.size > 1
+        @modify_entire_thread = true
+      end
+      @labels_to_remove
     end
 
     private
@@ -57,5 +64,8 @@ module Dug
     attr_reader :message
     attr_reader :servicer
 
+    def modify_entire_thread?
+      !!@modify_entire_thread
+    end
   end
 end

--- a/lib/dug/message_processor.rb
+++ b/lib/dug/message_processor.rb
@@ -25,6 +25,13 @@ module Dug
         end
       end
 
+      if message.indicates_reopened?
+        label = Dug.configuration.label_for(:state, 'closed')
+        reopened_label = Dug.configuration.label_for(:state, 'reopened')
+        labels_to_remove << label if label
+        labels_to_add << reopened_label if reopened_label
+      end
+
       info = "Processing message:"
       info << "\n    ID: #{message.id}"
       %w(Date From Subject).each do |header|

--- a/lib/dug/notification_decorator.rb
+++ b/lib/dug/notification_decorator.rb
@@ -34,6 +34,10 @@ module Dug
       !!(plaintext_body =~ /^Closed #(?:\d+)/)
     end
 
+    def indicates_reopened?
+      !!(plaintext_body =~ /^Reopened #(?:\d+)\./)
+    end
+
     private
 
     def list_match(index)

--- a/lib/dug/notification_decorator.rb
+++ b/lib/dug/notification_decorator.rb
@@ -24,10 +24,26 @@ module Dug
       end
     end
 
+    def indicates_merged?
+      !!(plaintext_body =~ /^Merged #(?:\d+)\./)
+    end
+
+    def indicates_closed?
+      # Note: Purposely more lax than Merged
+      # Issues can be closed via PR/commit ie "Closed #123 via #456."
+      !!(plaintext_body =~ /^Closed #(?:\d+)/)
+    end
+
     private
 
     def list_match(index)
       headers["List-ID"] && headers["List-ID"].match(/^([\w\-_]+)\/([\w\-_]+)/)[index]
+    end
+
+    def plaintext_body
+      payload.parts.detect { |part|
+        part.mime_type == 'text/plain'
+      }.body.data
     end
   end
 end

--- a/lib/dug/runner.rb
+++ b/lib/dug/runner.rb
@@ -33,9 +33,14 @@ module Dug
         @unprocessed_notifications = nil
       end
       unprocessed_label = servicer.labels(use_cache: use_cache)[Dug.configuration.unprocessed_label_name]
+
+      # The reverse! is required because we want to process messages in order
+      # and Google doesn't allow you to sort by anything because labels. Order
+      # is required here to account for state changes like reopened issues
       @unprocessed_notifications ||= servicer
         .list_user_messages('me', label_ids: [unprocessed_label.id])
         .messages
+        .reverse!
     end
 
     def unprocessed_notifications?

--- a/lib/dug/validations.rb
+++ b/lib/dug/validations.rb
@@ -19,9 +19,20 @@ module Dug
         raise InvalidGitHubReason, "'#{reason}' is not a valid GitHub notification reason. Valid reasons include: #{GITHUB_REASONS.map { |x| "'#{x}'" }.join(', ')}"
       end
     end
+
+    def valid_state?(state)
+      ISSUE_STATES.include?(state.to_s)
+    end
+
+    def validate_state!(state)
+      unless valid_state?(state)
+        raise InvalidIssueState, "'#{state}' is not a valid issue state. Valid reasons include: #{ISSUE_STATES.map { |x| "'#{x}'" }.join(', ')}"
+      end
+    end
   end
 
-  InvalidRuleType = Class.new(StandardError)
+  InvalidRuleType     = Class.new(StandardError)
   InvalidGitHubReason = Class.new(StandardError)
+  InvalidIssueState   = Class.new(StandardError)
 end
 

--- a/test/configurator/rule_file_fixtures/valid_rule_file.yml
+++ b/test/configurator/rule_file_fixtures/valid_rule_file.yml
@@ -20,3 +20,8 @@ reasons:
   mention: Mentioned
   team_mention: Team mention
   assign: Assigned to me
+
+states:
+  merged: Merged
+  closed: Closed
+  reopened: Reopened

--- a/test/message_processor_test.rb
+++ b/test/message_processor_test.rb
@@ -92,7 +92,7 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "dug", "Mentioned"]])
-      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"], entire_thread: false])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
       @mock_servicer.verify
@@ -105,7 +105,7 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "My dotfiles"]])
-      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"], entire_thread: false])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
       @mock_servicer.verify
@@ -118,7 +118,7 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Julian's dotfiles"]])
-      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"], entire_thread: false])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
       @mock_servicer.verify
@@ -131,7 +131,7 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub"]])
-      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"], entire_thread: false])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
       @mock_servicer.verify
@@ -145,7 +145,7 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "dug", "Merged"]])
-      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"], entire_thread: false])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
       @mock_servicer.verify
@@ -159,7 +159,7 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "dug", "Closed"]])
-      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"], entire_thread: false])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
       @mock_servicer.verify
@@ -173,7 +173,7 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "dug", "Reopened"]])
-      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed", "Closed"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed", "Closed"], entire_thread: true])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
       @mock_servicer.verify

--- a/test/message_processor_test.rb
+++ b/test/message_processor_test.rb
@@ -22,6 +22,14 @@ class MessageProcessorTest < MiniTest::Test
     def reason
       nil
     end
+
+    def indicates_merged?
+      false
+    end
+
+    def indicates_closed?
+      false
+    end
   end
 
   class MentionedMessage < BaseMessage

--- a/test/message_processor_test.rb
+++ b/test/message_processor_test.rb
@@ -30,6 +30,10 @@ class MessageProcessorTest < MiniTest::Test
     def indicates_closed?
       false
     end
+
+    def indicates_reopened?
+      false
+    end
   end
 
   class MentionedMessage < BaseMessage

--- a/test/message_processor_test.rb
+++ b/test/message_processor_test.rb
@@ -42,6 +42,12 @@ class MessageProcessorTest < MiniTest::Test
     end
   end
 
+  class MergedMessage < BaseMessage
+    def indicates_merged?
+      true
+    end
+  end
+
   class MultipleRemotesPossible < BaseMessage
     def repository
       "dotfiles"
@@ -113,6 +119,20 @@ class MessageProcessorTest < MiniTest::Test
     Dug::NotificationDecorator.stub :new, @mock_message do
       @mock_servicer.expect(:get_user_message, nil, [String, String])
       @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub"]])
+      @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
+
+      Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute
+      @mock_servicer.verify
+    end
+  end
+
+  def test_merged_message
+    @mock_message = MergedMessage.new
+
+
+    Dug::NotificationDecorator.stub :new, @mock_message do
+      @mock_servicer.expect(:get_user_message, nil, [String, String])
+      @mock_servicer.expect(:add_labels_by_name, nil, [@mock_message, ["GitHub", "Chris Arcand", "dug", "Merged"]])
       @mock_servicer.expect(:remove_labels_by_name, nil, [@mock_message, ["GitHub/Unprocessed"]])
 
       Dug::MessageProcessor.new("dummy_id", @mock_servicer).execute


### PR DESCRIPTION
Adds a 'states' type with built-in support for Merged, Closed, and Reopened notifications.

This also changes some configuration loading and processing so I'm currently testing it in a dev branch to see if there are any odd error. Covered mostly in spec but not entirely as I'm much too lazy to stub out Gmail's heavily-nested plaintext bodies.
