### PR TITLE
Fix commit notifications

### DIFF
--- a/lib/dug/notification_decorator.rb
+++ b/lib/dug/notification_decorator.rb
@@ -45,9 +45,11 @@ module Dug
     end
 
     def plaintext_body
-      payload.parts.detect { |part|
-        part.mime_type == 'text/plain'
-      }.body.data
+      @plaintext_body ||= \
+        begin
+          parts = payload.parts || Array(payload)
+          parts.detect { |part| part.mime_type == 'text/plain' }.body.data
+        end
     end
   end
 end


### PR DESCRIPTION
Closes #16 aka "The Julian Bug"

Apparently commit notifications don't send an HTML payload (only plaintext) so the notification decorator needs to take into account when there are not multiple message parts.

Also memoizes this method as we were parsing it multiple times on each plaintext body check.
