### PR TITLE
add 'your_activity' to list of github reasons

### DIFF
--- a/lib/dug.rb
+++ b/lib/dug.rb
@@ -10,7 +10,7 @@ require "dug/util"
 
 module Dug
   LABEL_RULE_TYPES = %w(organization repository reason state)
-  GITHUB_REASONS = %w(author comment mention team_mention state_change assign manual subscribed push)
+  GITHUB_REASONS = %w(author comment mention team_mention state_change assign manual subscribed push your_activity)
   ISSUE_STATES = %(merged closed reopened)
 
   def self.authorize!


### PR DESCRIPTION
this is set, if you enable 'Include your own updates' in your
github profile notification settings
![](https://www.evernote.com/shard/s1/sh/2da17173-e352-4242-965f-8e456e5fcd96/4ae4db49a4e136becf6ad2d5e78c0a51/res/d3cb764d-3bc6-490d-95a2-70c0d0da014a/github.com.jpg?resizeSmall)
