### PR TITLE
Add Dockerfile, templates, and documentation to use the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.3.1
+MAINTAINER Drew Bomhof (syncrou) https://github.com/syncrou
+
+ENV APP_ROOT dug
+
+RUN gem install dug --no-ri --no-rdoc
+
+RUN mkdir ${APP_ROOT} && cd ${APP_ROOT}
+
+COPY templates/dug_rules.yml ${APP_ROOT}
+
+COPY templates/script.rb ${APP_ROOT}
+
+CMD [ "ruby", "dug/script.rb" ]

--- a/README.md
+++ b/README.md
@@ -180,6 +180,36 @@ Dug.configure do |config|
 end
 ```
 
+## Dockerfile
+
+The included Docker file will build a ruby 2.3.1 image
+and run the script `templates/script.rb` every 180 seconds
+using the rules in `templates/dug_rules.yml`.
+
+The steps below explain how to build the container and 
+run timely updates on your gmail account labels.
+
+1. Edit both `templates/dug_rules.yml` and `templates/script.rb` to
+your liking.
+
+2. Build the image - `docker build -t dug_tagger .`
+
+3. Build and run the container - `docker run -idt dug_tagger`
+
+4. Copy the resulting Container id SHA (or tag) from step 3.
+
+5. Access the container to verify the Gmail one time token - `docker exec -it <container id sha> /bin/bash`
+
+6. From the the `/root` folder run `ruby /dug/script.rb`
+You should see a request for the Gmail one time token.
+
+6. Copy the token and then exit out of the interactive session - `exit`
+
+7. Restart the container to pick up the Gmail token - `docker restart <container id sha>`
+
+8. You should start to see email in your `UnProcessed` folder decrease after the time
+interval has passed in your `templates/script.rb` file.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/templates/dug_rules.yml
+++ b/templates/dug_rules.yml
@@ -1,0 +1,22 @@
+---
+organizations:
+  ManageIQ: ManageIQ
+
+repositories:
+  dug: dug
+  dotfiles:
+    - remote: chrisarcand
+      label: My dotfiles
+    - remote: juliancheal
+      label: Julian's dotfiles
+
+reasons:
+  author: Participating
+  comment: Participating
+  mention: Mentioned
+  team_mention: Team mention
+  assign: Assigned to me
+
+states:
+  merged: Merged
+  closed: Closed

--- a/templates/script.rb
+++ b/templates/script.rb
@@ -1,10 +1,12 @@
 require 'dug'
+cert_path = Gem.loaded_specs['google-api-client'].full_gem_path+'/lib/cacerts.pem'
+ENV['SSL_CERT_FILE'] = cert_path
 
 Dug.configure do |config|
  # You can alternatively pass environment variables
  # or a path to a downloadable authentication .json file from Google
- config.client_id = "<google oauth client id>"
- config.client_secret = "<google secret>"
+ config.client_id = "<google client id>"
+ config.client_secret = "<google client secret>"
 
  config.rule_file = File.join(Dir.pwd, "/dug/dug_rules.yml")
 end

--- a/templates/script.rb
+++ b/templates/script.rb
@@ -1,0 +1,18 @@
+require 'dug'
+
+Dug.configure do |config|
+ # You can alternatively pass environment variables
+ # or a path to a downloadable authentication .json file from Google
+ config.client_id = "<google oauth client id>"
+ config.client_secret = "<google secret>"
+
+ config.rule_file = File.join(Dir.pwd, "/dug/dug_rules.yml")
+end
+loop do
+  begin
+    Dug::Runner.run
+    sleep 180
+  rescue => e
+    puts "Error connecting to Gmail: #{e.inspect}"
+  end
+end


### PR DESCRIPTION
Add a Dockerfile including default `script.rb` and `dug_rules.yml` templates.

Added Docs to `README.md` explaining how best to set up the container for continuous DUG goodness!
